### PR TITLE
fixing incorrect display of tax summaries in invoice, credit note and order templates

### DIFF
--- a/src/main/resources/xsl/html/billing-3/CommonTemplates.xsl
+++ b/src/main/resources/xsl/html/billing-3/CommonTemplates.xsl
@@ -3105,7 +3105,7 @@
                     </xsl:if>
                 </small>
             </div>
-            <div class="items_table_body_data">
+            <div class="items_table_body_data text_right">
                 <xsl:if test="cbc:InvoicedQuantity !=''">
                     <xsl:apply-templates select="cbc:InvoicedQuantity" />&#8201;
                     <xsl:if test="cbc:InvoicedQuantity/@unitCode !=''">
@@ -3143,7 +3143,7 @@
                     </xsl:if>
                 </xsl:if>
             </div>
-            <div class="items_table_body_data">
+            <div class="items_table_body_data text_right">
                 <xsl:call-template name="Currency">
                     <xsl:with-param name="currencyvalue" select="cac:Price/cbc:PriceAmount" />
                     <xsl:with-param name="country" select="$languageCode" />
@@ -3161,7 +3161,7 @@
                     </small>
                 </xsl:if>
             </div>
-            <div class="items_table_body_data">
+            <div class="items_table_body_data text_right">
                 <xsl:if test="cac:Item/cac:ClassifiedTaxCategory !='' ">
                     <xsl:choose>
                         <xsl:when test="cac:Item/cac:ClassifiedTaxCategory/cbc:Percent !=''">
@@ -3529,40 +3529,42 @@
     <!-- AllowanceCharge end -->
     <!-- Tax (VAT) totals from here: -->
     <xsl:template match="cac:TaxTotal/cac:TaxSubtotal">
-        <div class="tax_table_body_data col-10">
-            <xsl:apply-templates select="cac:TaxCategory/cbc:ID" />
-            <xsl:call-template name="NumberFormat">
-                <xsl:with-param name="value" select="cac:TaxCategory/cbc:Percent" />
-                <xsl:with-param name="formatToDecimal" select="'false'" />
-                <xsl:with-param name="country" select="$languageCode" />
-            </xsl:call-template>
-        </div>
-        <div class="tax_table_body_data col-30">
-            <xsl:choose>
-                <xsl:when test="cac:TaxCategory/cbc:Percent !=''">
-                &#8201;
-                    [<xsl:call-template name="NumberFormat">
-                        <xsl:with-param name="value" select="cac:TaxCategory/cbc:Percent" />
-                        <xsl:with-param name="formatToDecimal" select="'true'" />
-                        <xsl:with-param name="country" select="$languageCode" />
-                    </xsl:call-template>%]
-                </xsl:when>
-                <xsl:otherwise>
-                    %
-                </xsl:otherwise>
-            </xsl:choose>
-        </div>
-        <div class="tax_table_body_data col-30">
-            <xsl:call-template name="Currency">
-                <xsl:with-param name="currencyvalue" select="cbc:TaxableAmount" />
-                <xsl:with-param name="country" select="$languageCode" />
-            </xsl:call-template>
-        </div>
-        <div class="tax_table_body_data col-30">
-            <xsl:call-template name="Currency">
-                <xsl:with-param name="currencyvalue" select="cbc:TaxAmount" />
-                <xsl:with-param name="country" select="$languageCode" />
-            </xsl:call-template>
+        <div class="table_body_data_row1 row">
+            <div class="tax_table_body_data col-10">
+                <xsl:apply-templates select="cac:TaxCategory/cbc:ID" />
+                <xsl:call-template name="NumberFormat">
+                    <xsl:with-param name="value" select="cac:TaxCategory/cbc:Percent" />
+                    <xsl:with-param name="formatToDecimal" select="'false'" />
+                    <xsl:with-param name="country" select="$languageCode" />
+                </xsl:call-template>
+            </div>
+            <div class="tax_table_body_data col-30">
+                <xsl:choose>
+                    <xsl:when test="cac:TaxCategory/cbc:Percent !=''">
+                    &#8201;
+                        [<xsl:call-template name="NumberFormat">
+                            <xsl:with-param name="value" select="cac:TaxCategory/cbc:Percent" />
+                            <xsl:with-param name="formatToDecimal" select="'true'" />
+                            <xsl:with-param name="country" select="$languageCode" />
+                        </xsl:call-template>%]
+                    </xsl:when>
+                    <xsl:otherwise>
+                        %
+                    </xsl:otherwise>
+                </xsl:choose>
+            </div>
+            <div class="tax_table_body_data col-30">
+                <xsl:call-template name="Currency">
+                    <xsl:with-param name="currencyvalue" select="cbc:TaxableAmount" />
+                    <xsl:with-param name="country" select="$languageCode" />
+                </xsl:call-template>
+            </div>
+            <div class="tax_table_body_data col-30">
+                <xsl:call-template name="Currency">
+                    <xsl:with-param name="currencyvalue" select="cbc:TaxAmount" />
+                    <xsl:with-param name="country" select="$languageCode" />
+                </xsl:call-template>
+            </div>
         </div>
     </xsl:template>
     <xsl:template name="cac:PaymentMeans">

--- a/src/main/resources/xsl/html/billing-3/Headlines-BT_en.xml
+++ b/src/main/resources/xsl/html/billing-3/Headlines-BT_en.xml
@@ -745,7 +745,7 @@ If remittance information is to be mapped to the End To End Identification field
 - Services outside scope of tax (Sale is not subject to VAT/IGIC/IPSI)
 - Canary Islands General Indirect Tax (Liable for IGIC tax)
 - Liable for IPSI (Ceuta/Melilla tax)</Description>
-		<DisplayName>VAT category code</DisplayName>
+		<DisplayName>VAT</DisplayName>
 	</BusinessTerm>
 	<BusinessTerm id="BT-103">
 		<TermName>Document level charge VAT rate</TermName>

--- a/src/main/resources/xsl/html/common/user_config.xsl
+++ b/src/main/resources/xsl/html/common/user_config.xsl
@@ -10,5 +10,5 @@
     xmlns:ccts="urn:oasis:names:specification:ubl:schema:xsd:CoreComponentParameters-2"
     xmlns:sdt="urn:oasis:names:specification:ubl:schema:xsd:SpecializedDatatypes-2"
     xmlns:udt="urn:un:unece:uncefact:data:specification:UnqualifiedDataTypesSchemaModule:2" exclude-result-prefixes="n1 n2 cdl cac cbc ccts sdt udt">
-    <xsl:param name="languageCode" select="'en'"/>
+    <xsl:param name="languageCode" select="'is'"/>
 </xsl:stylesheet>

--- a/src/main/resources/xsl/html/procurement/render-order.xsl
+++ b/src/main/resources/xsl/html/procurement/render-order.xsl
@@ -208,7 +208,7 @@
                     }
                     .items_table_header_title:nth-child(3),
                     .items_table_body_data:nth-child(3) {
-                        width: 33%;
+                        width: 30%;
                     }
                     .items_table_header_title:nth-child(4),
                     .items_table_body_data:nth-child(4) {
@@ -216,11 +216,11 @@
                     }
                     .items_table_header_title:nth-child(5),
                     .items_table_body_data:nth-child(5) {
-                        width: 12%;
+                        width: 11%;
                     }
                     .items_table_header_title:nth-child(6),
                     .items_table_body_data:nth-child(6) {
-                        width: 6%;
+                        width: 10%;
                     }
                     .items_table_header_title:nth-child(7),
                     .items_table_body_data:nth-child(7) {
@@ -921,7 +921,7 @@
                                                     </xsl:call-template>
                                                 </b>
                                             </div>
-                                            <div class="items_table_header_title">
+                                            <div class="items_table_header_title text_right">
                                                 <b>
                                                     <xsl:call-template name="LabelName">
                                                         <xsl:with-param name="BT-ID" select="'BT-129'"/>
@@ -929,7 +929,7 @@
                                                     </xsl:call-template>
                                                 </b>
                                             </div>
-                                            <div class="items_table_header_title">
+                                            <div class="items_table_header_title text_right">
                                                 <b>
                                                     <xsl:call-template name="LabelName">
                                                         <xsl:with-param name="BT-ID" select="'BT-146'"/>
@@ -937,10 +937,10 @@
                                                     </xsl:call-template>
                                                 </b>
                                             </div>
-                                            <div class="items_table_header_title">
+                                            <div class="items_table_header_title text_right">
                                                 <b>
                                                     <xsl:call-template name="LabelName">
-                                                        <xsl:with-param name="BT-ID" select="'BT-151'"/>
+                                                        <xsl:with-param name="BT-ID" select="'BT-102'"/>
                                                         <xsl:with-param name="Colon-Suffix" select="'false'"/>
                                                     </xsl:call-template>
                                                 </b>
@@ -1216,7 +1216,7 @@
                                     <p class="green_title">
                                         <xsl:call-template name="UMZLabelName">
                                             <xsl:with-param name="BT-ID" select="'UMZ-BT-041'"/>
-                                            <xsl:with-param name="Colon-Suffix" select="'true'"/>
+                                            <xsl:with-param name="Colon-Suffix" select="'false'"/>
                                         </xsl:call-template>
                                     </p>
                                     <div class="green_box_no_back">
@@ -1227,7 +1227,7 @@
                                             <p class="green_title">
                                                 <xsl:call-template name="UMZLabelName">
                                                     <xsl:with-param name="BT-ID" select="'UMZ-BT-027'" />
-                                                    <xsl:with-param name="Colon-Suffix" select="'true'" />
+                                                    <xsl:with-param name="Colon-Suffix" select="'false'" />
                                                 </xsl:call-template>
                                             </p>
                                             <div class="green_box_no_back">
@@ -1240,7 +1240,7 @@
                                     <p class="green_title">
                                         <xsl:call-template name="LabelName">
                                             <xsl:with-param name="BT-ID" select="'BT-33'"/>
-                                            <xsl:with-param name="Colon-Suffix" select="'true'"/>
+                                            <xsl:with-param name="Colon-Suffix" select="'false'"/>
                                         </xsl:call-template>
                                     </p>
                                     <div class="green_box_no_back">
@@ -1251,7 +1251,7 @@
                                     <p class="green_title">
                                         <xsl:call-template name="UMZLabelName">
                                             <xsl:with-param name="BT-ID" select="'UMZ-BT-009'"/>
-                                            <xsl:with-param name="Colon-Suffix" select="'true'"/>
+                                            <xsl:with-param name="Colon-Suffix" select="'false'"/>
                                         </xsl:call-template>
                                     </p>
                                     <div class="green_box_no_back">
@@ -1270,7 +1270,7 @@
                                         <p class="green_title">
                                             <xsl:call-template name="LabelName">
                                                 <xsl:with-param name="BT-ID" select="'BG-13'"/>
-                                                <xsl:with-param name="Colon-Suffix" select="'true'"/>
+                                                <xsl:with-param name="Colon-Suffix" select="'false'"/>
                                             </xsl:call-template>
                                         </p>
                                         <div class="green_box_no_back">
@@ -1284,7 +1284,7 @@
                                         <p class="green_title">
                                             <xsl:call-template name="LabelName">
                                                 <xsl:with-param name="BT-ID" select="'BG-24'"/>
-                                                <xsl:with-param name="Colon-Suffix" select="'true'"/>
+                                                <xsl:with-param name="Colon-Suffix" select="'false'"/>
                                             </xsl:call-template>
                                         </p>
                                         <div class="green_box_no_back">

--- a/src/main/resources/xsl/html/render-billing-3.xsl
+++ b/src/main/resources/xsl/html/render-billing-3.xsl
@@ -1879,9 +1879,7 @@
                                         </div>
                                     </div>
                                     <div class="table_body">
-                                        <div class="table_body_data_row1 row">
-                                            <xsl:apply-templates select="cac:TaxTotal/cac:TaxSubtotal"/>
-                                        </div>
+                                        <xsl:apply-templates select="cac:TaxTotal/cac:TaxSubtotal"/>
                                         <div class="table_body_data_row2">
                                             <div class="tax_table_body_data">
                                                 <xsl:if test="cac:TaxTotal/cbc:TaxAmount">

--- a/src/main/resources/xsl/html/render-billing-3.xsl
+++ b/src/main/resources/xsl/html/render-billing-3.xsl
@@ -430,7 +430,7 @@
                     }
                     .items_table_header_title:nth-child(3),
                     .items_table_body_data:nth-child(3) {
-                        width: 33%;
+                        width: 30%;
                     }
                     .items_table_header_title:nth-child(4),
                     .items_table_body_data:nth-child(4) {
@@ -438,11 +438,11 @@
                     }
                     .items_table_header_title:nth-child(5),
                     .items_table_body_data:nth-child(5) {
-                        width: 12%;
+                        width: 11%;
                     }
                     .items_table_header_title:nth-child(6),
                     .items_table_body_data:nth-child(6) {
-                        width: 6%;
+                        width: 10%;
                     }
                     .items_table_header_title:nth-child(7),
                     .items_table_body_data:nth-child(7) {
@@ -489,13 +489,13 @@
 
 
                     .tax_table .table_body .table_body_data_row1 {
-                        border-bottom: 1px solid #A6C3D1;
                         justify-content: flex-end;
                     }
 
                     .tax_table .table_body .table_body_data_row2 {
                         display: flex;
                         justify-content: flex-end;
+                        border-top: 1px solid #A6C3D1;
                     }
 
                     .tax_table .table_body .tax_table_body_data {
@@ -1670,7 +1670,7 @@
                                                 </xsl:call-template>
                                             </b>
                                         </div>
-                                        <div class="items_table_header_title">
+                                        <div class="items_table_header_title text_right">
                                             <b>
                                                 <xsl:call-template name="LabelName">
                                                     <xsl:with-param name="BT-ID" select="'BT-129'"/>
@@ -1678,7 +1678,7 @@
                                                 </xsl:call-template>
                                             </b>
                                         </div>
-                                        <div class="items_table_header_title">
+                                        <div class="items_table_header_title text_right">
                                             <b>
                                                 <xsl:call-template name="LabelName">
                                                     <xsl:with-param name="BT-ID" select="'BT-146'"/>
@@ -1686,10 +1686,10 @@
                                                 </xsl:call-template>
                                             </b>
                                         </div>
-                                        <div class="items_table_header_title">
+                                        <div class="items_table_header_title text_right">
                                             <b>
                                                 <xsl:call-template name="LabelName">
-                                                    <xsl:with-param name="BT-ID" select="'BT-151'"/>
+                                                    <xsl:with-param name="BT-ID" select="'BT-102'"/>
                                                     <xsl:with-param name="Colon-Suffix" select="'false'"/>
                                                 </xsl:call-template>
                                             </b>
@@ -1742,7 +1742,7 @@
                                                 </xsl:call-template>
                                             </b>
                                         </div>
-                                        <div class="items_table_header_title">
+                                        <div class="items_table_header_title text_right">
                                             <b>
                                                 <xsl:call-template name="LabelName">
                                                     <xsl:with-param name="BT-ID" select="'BT-129'"/>
@@ -1750,7 +1750,7 @@
                                                 </xsl:call-template>
                                             </b>
                                         </div>
-                                        <div class="items_table_header_title">
+                                        <div class="items_table_header_title text_right">
                                             <b>
                                                 <xsl:call-template name="LabelName">
                                                     <xsl:with-param name="BT-ID" select="'BT-146'"/>
@@ -1758,10 +1758,10 @@
                                                 </xsl:call-template>
                                             </b>
                                         </div>
-                                        <div class="items_table_header_title">
+                                        <div class="items_table_header_title text_right">
                                             <b>
                                                 <xsl:call-template name="LabelName">
-                                                    <xsl:with-param name="BT-ID" select="'BT-151'"/>
+                                                    <xsl:with-param name="BT-ID" select="'BT-102'"/>
                                                     <xsl:with-param name="Colon-Suffix" select="'false'"/>
                                                 </xsl:call-template>
                                             </b>
@@ -1805,7 +1805,7 @@
                                             <b>
                                                 <xsl:call-template name="LabelName">
                                                     <xsl:with-param name="BT-ID" select="'BT-118'"/>
-                                                    <xsl:with-param name="Colon-Suffix" select="'true'"/>
+                                                    <xsl:with-param name="Colon-Suffix" select="'false'"/>
                                                 </xsl:call-template>
                                             </b>
                                         </div>
@@ -1813,7 +1813,7 @@
                                             <b>
                                                 <xsl:call-template name="LabelName">
                                                     <xsl:with-param name="BT-ID" select="'BT-116'"/>
-                                                    <xsl:with-param name="Colon-Suffix" select="'true'"/>
+                                                    <xsl:with-param name="Colon-Suffix" select="'false'"/>
                                                 </xsl:call-template>
                                             </b>
                                         </div>
@@ -1821,15 +1821,13 @@
                                             <b>
                                                 <xsl:call-template name="LabelName">
                                                     <xsl:with-param name="BT-ID" select="'BT-117'"/>
-                                                    <xsl:with-param name="Colon-Suffix" select="'true'"/>
+                                                    <xsl:with-param name="Colon-Suffix" select="'false'"/>
                                                 </xsl:call-template>
                                             </b>
                                         </div>
                                     </div>
                                     <div class="table_body">
-                                        <div class="table_body_data_row1 row">
-                                            <xsl:apply-templates select="cac:TaxTotal/cac:TaxSubtotal"/>
-                                        </div>
+                                        <xsl:apply-templates select="cac:TaxTotal/cac:TaxSubtotal"/>
                                         <div class="table_body_data_row2">
                                             <div class="tax_table_body_data">
                                                 <xsl:if test="cac:TaxTotal/cbc:TaxAmount">
@@ -1859,7 +1857,7 @@
                                             <b>
                                                 <xsl:call-template name="LabelName">
                                                     <xsl:with-param name="BT-ID" select="'BT-118'"/>
-                                                    <xsl:with-param name="Colon-Suffix" select="'true'"/>
+                                                    <xsl:with-param name="Colon-Suffix" select="'false'"/>
                                                 </xsl:call-template>
                                             </b>
                                         </div>
@@ -1867,7 +1865,7 @@
                                             <b>
                                                 <xsl:call-template name="LabelName">
                                                     <xsl:with-param name="BT-ID" select="'BT-116'"/>
-                                                    <xsl:with-param name="Colon-Suffix" select="'true'"/>
+                                                    <xsl:with-param name="Colon-Suffix" select="'false'"/>
                                                 </xsl:call-template>
                                             </b>
                                         </div>
@@ -1875,7 +1873,7 @@
                                             <b>
                                                 <xsl:call-template name="LabelName">
                                                     <xsl:with-param name="BT-ID" select="'BT-117'"/>
-                                                    <xsl:with-param name="Colon-Suffix" select="'true'"/>
+                                                    <xsl:with-param name="Colon-Suffix" select="'false'"/>
                                                 </xsl:call-template>
                                             </b>
                                         </div>
@@ -2140,7 +2138,7 @@
                                     <p class="blue_title">
                                         <xsl:call-template name="LabelName">
                                             <xsl:with-param name="BT-ID" select="'BG-15'"/>
-                                            <xsl:with-param name="Colon-Suffix" select="'true'"/>
+                                            <xsl:with-param name="Colon-Suffix" select="'false'"/>
                                         </xsl:call-template>
                                     </p>
                                     <div class="blue_box_no_back">
@@ -2155,7 +2153,7 @@
                                     <p class="blue_title">
                                         <xsl:call-template name="LabelName">
                                             <xsl:with-param name="BT-ID" select="'BG-10'"/>
-                                            <xsl:with-param name="Colon-Suffix" select="'true'"/>
+                                            <xsl:with-param name="Colon-Suffix" select="'false'"/>
                                         </xsl:call-template>
                                     </p>
                                     <div class="blue_box_no_back">
@@ -2172,7 +2170,7 @@
                                     <p class="red_title">
                                         <xsl:call-template name="LabelName">
                                             <xsl:with-param name="BT-ID" select="'BG-15'"/>
-                                            <xsl:with-param name="Colon-Suffix" select="'true'"/>
+                                            <xsl:with-param name="Colon-Suffix" select="'false'"/>
                                         </xsl:call-template>
                                     </p>
                                     <div class="red_box_no_back">
@@ -2187,7 +2185,7 @@
                                     <p class="red_title">
                                         <xsl:call-template name="LabelName">
                                             <xsl:with-param name="BT-ID" select="'BG-10'"/>
-                                            <xsl:with-param name="Colon-Suffix" select="'true'"/>
+                                            <xsl:with-param name="Colon-Suffix" select="'false'"/>
                                         </xsl:call-template>
                                     </p>
                                     <div class="red_box_no_back">
@@ -2206,7 +2204,7 @@
                                 <p class="blue_title">
                                     <xsl:call-template name="LabelName">
                                         <xsl:with-param name="BT-ID" select="'BT-33'"/>
-                                        <xsl:with-param name="Colon-Suffix" select="'true'"/>
+                                        <xsl:with-param name="Colon-Suffix" select="'false'"/>
                                     </xsl:call-template>
                                 </p>
                                 <div class="blue_box_no_back">
@@ -2217,7 +2215,7 @@
                                 <p class="red_title">
                                     <xsl:call-template name="LabelName">
                                         <xsl:with-param name="BT-ID" select="'BT-33'"/>
-                                        <xsl:with-param name="Colon-Suffix" select="'true'"/>
+                                        <xsl:with-param name="Colon-Suffix" select="'false'"/>
                                     </xsl:call-template>
                                 </p>
                                 <div class="red_box_no_back">
@@ -2230,7 +2228,7 @@
                                 <p class="blue_title">
                                     <xsl:call-template name="UMZLabelName">
                                         <xsl:with-param name="BT-ID" select="'UMZ-BT-009'"/>
-                                        <xsl:with-param name="Colon-Suffix" select="'true'"/>
+                                        <xsl:with-param name="Colon-Suffix" select="'false'"/>
                                     </xsl:call-template>
                                 </p>
                                 <div class="blue_box_no_back">
@@ -2338,7 +2336,7 @@
                                 <p class="red_title">
                                     <xsl:call-template name="UMZLabelName">
                                         <xsl:with-param name="BT-ID" select="'UMZ-BT-009'"/>
-                                        <xsl:with-param name="Colon-Suffix" select="'true'"/>
+                                        <xsl:with-param name="Colon-Suffix" select="'false'"/>
                                     </xsl:call-template>
                                 </p>
                                 <div class="red_box_no_back">


### PR DESCRIPTION
- fixing tax table row to render every line below each other
- fixing IS translations for VAT category
- removing colon from labels where is not needed
- aligning Quantity, Unit amount and VAT columns to right and changing the size of columns