### PR TITLE
adding styles for .col-50 CSS class

### DIFF
--- a/src/main/resources/xsl/html/procurement/render-order.xsl
+++ b/src/main/resources/xsl/html/procurement/render-order.xsl
@@ -327,6 +327,14 @@
                     .col-75 {
                         width: 75%;
                         }
+                    
+                    .col-50.margin-right-big:only-child {
+                        width: calc(50% - 1em)
+                        }
+
+                    .col-50.margin-right-small:only-child {
+                        width: calc(50% - 0.5em)
+                        }
 
                     .margin-right-big {
                         margin-right: 2em;

--- a/src/main/resources/xsl/html/render-billing-3.xsl
+++ b/src/main/resources/xsl/html/render-billing-3.xsl
@@ -583,6 +583,14 @@
                     .col-75 {
                         width: 75%;
                         }
+                        
+                    .col-50.margin-right-big:only-child {
+                        width: calc(50% - 1em)
+                        }
+
+                    .col-50.margin-right-small:only-child {
+                        width: calc(50% - 0.5em)
+                        }
 
                     .margin-right-big {
                         margin-right: 2em;


### PR DESCRIPTION
adding styles for .col-50 CSS class for calculating box width to be 50% - margin/2 of margin-right class if that box is the only child of .row in invoice, credit note and order stylesheet